### PR TITLE
Support loading custom languages from _config.yml

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const shiki = require("shiki");
-const fs = require("fs");
+const fsPromises = require("fs/promises");
 const config = (hexo.config.shiki = Object.assign(
     {
         renderer: "marked",
@@ -12,9 +12,9 @@ return shiki
     .getHighlighter({
         theme: config.theme,
     })
-    .then((hl) => {
-        config.languages.forEach(async lang => {
-            const grammarDef = JSON.parse(fs.readFileSync("./" + lang.grammar));
+    .then(async (hl) => {
+        for (const lang of config.languages) {
+            const grammarDef = JSON.parse(await fsPromises.readFile(lang.grammar));
             const langDef = {
                 id: lang.id,
                 scopeName: lang.scope_name,
@@ -22,7 +22,7 @@ return shiki
                 aliases: lang.aliases || [],
             };
             await hl.loadLanguage(langDef);
-        });
+        }
         if (config.renderer === "djot") {
             hexo.extend.filter.register("djot:renderer", (renderOverrides) => {
                 renderOverrides.code_block = (node) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 const shiki = require("shiki");
+const fs = require("fs");
 const config = (hexo.config.shiki = Object.assign(
     {
         renderer: "marked",
         theme: "github-light",
+        languages: [],
     },
     hexo.config.shiki || {}
 ));
@@ -11,6 +13,16 @@ return shiki
         theme: config.theme,
     })
     .then((hl) => {
+        config.languages.forEach(async lang => {
+            const grammarDef = JSON.parse(fs.readFileSync("./" + lang.grammar));
+            const langDef = {
+                id: lang.id,
+                scopeName: lang.scope_name,
+                grammar: grammarDef,
+                aliases: lang.aliases || [],
+            };
+            await hl.loadLanguage(langDef);
+        });
         if (config.renderer === "djot") {
             hexo.extend.filter.register("djot:renderer", (renderOverrides) => {
                 renderOverrides.code_block = (node) => {


### PR DESCRIPTION
Thank you for building this plugin—I was looking for a syntax highlighter that supports custom languages, and your plugin works great. I added this feature for myself, but I thought I would offer it as a general suggestion. I apologize if the implementation is sloppy.

This lets you load custom languages by defining them in `_config.yml`:

```yml
shiki:
  theme: 'github-dark'
  languages:
    - id: 'm68k'
      scope_name: 'source.asm.m68k'
      grammar: 'grammars/M68k-Assembly.tmLanguage.json'
```

The grammar file path is relative to the root of the Hexo project.